### PR TITLE
remove unwanted detected ports on MacOS

### DIFF
--- a/platformio/device/finder.py
+++ b/platformio/device/finder.py
@@ -160,7 +160,9 @@ class SerialPortFinder:
         if sys.platform == "darwin":
             port_list = [
                 item for item in port_list
-                if not item["port"].endswith(("Bluetooth-Incoming-Port", "wlan-debug", "debug-console"))
+                if not item["port"].endswith(
+                    ("Bluetooth-Incoming-Port", "wlan-debug", "debug-console")
+                )
             ]
         for item in port_list:
             if self.ensure_ready and not is_serial_port_ready(item["port"]):

--- a/platformio/device/finder.py
+++ b/platformio/device/finder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 from fnmatch import fnmatch
 from functools import lru_cache
 
@@ -154,7 +155,14 @@ class SerialPortFinder:
 
         # pick the best PID:VID USB device
         port = best_port = None
-        for item in list_serial_ports():
+        port_list = list_serial_ports()
+        # macOS-specific: filter out unwanted ports
+        if sys.platform == "darwin":
+            port_list = [
+                item for item in port_list
+                if not item["port"].endswith(("Bluetooth-Incoming-Port", "wlan-debug", "debug-console"))
+            ]
+        for item in port_list:
             if self.ensure_ready and not is_serial_port_ready(item["port"]):
                 continue
             port = item["port"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device discovery on macOS by filtering out Bluetooth-Incoming-Port, wlan-debug, and debug-console ports that could interfere with proper device detection and connection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->