### PR TITLE
Add support for subdirectories when adding git repos as a library

### DIFF
--- a/platformio/package/manager/_install.py
+++ b/platformio/package/manager/_install.py
@@ -193,7 +193,15 @@ class PackageManagerInstallMixin:
                 vcs = VCSClientFactory.new(tmp_dir, uri)
                 assert vcs.export()
 
-            root_dir = self.find_pkg_root(tmp_dir, spec)
+            pkg_dir = tmp_dir
+            if vcs and vcs.subdir:
+                pkg_dir = os.path.join(tmp_dir, vcs.subdir)
+                if not os.path.isdir(pkg_dir):
+                    raise PackageException(
+                        "Subdirectory '%s' not found in the repository" % vcs.subdir
+                    )
+
+            root_dir = self.find_pkg_root(pkg_dir, spec)
             pkg_item = PackageItem(
                 root_dir,
                 self.build_metadata(

--- a/platformio/package/manager/_install.py
+++ b/platformio/package/manager/_install.py
@@ -195,7 +195,11 @@ class PackageManagerInstallMixin:
 
             pkg_dir = tmp_dir
             if vcs and vcs.subdir:
-                pkg_dir = os.path.join(tmp_dir, vcs.subdir)
+                pkg_dir = os.path.realpath(os.path.join(tmp_dir, vcs.subdir))
+                if not pkg_dir.startswith(os.path.realpath(tmp_dir) + os.sep):
+                    raise PackageException(
+                        "Invalid subdirectory '%s'" % vcs.subdir
+                    )
                 if not os.path.isdir(pkg_dir):
                     raise PackageException(
                         "Subdirectory '%s' not found in the repository" % vcs.subdir

--- a/platformio/package/meta.py
+++ b/platformio/package/meta.py
@@ -428,22 +428,14 @@ class PackageSpec:  # pylint: disable=too-many-instance-attributes
         # Handle browse URLs with subdirectory
         # GitHub/GitLab: /user/repo/tree/branch/subdir
         if parts.netloc in ("github.com", "gitlab.com"):
-            path_parts = [p for p in parts.path.split("/") if p and p != "-"]
-            try:
-                tree_idx = path_parts.index("tree")
-                if tree_idx >= 2 and len(path_parts) > tree_idx + 2:
-                    return path_parts[-1]
-            except ValueError:
-                pass
+        path_parts = [p for p in parts.path.split("/") if p and p != "-"]
+        if len(path_parts) >= 5 and path_parts[2] == "tree":
+            return path_parts[-1]
         # Bitbucket: /user/repo/src/branch/subdir
         elif parts.netloc in ("bitbucket.org", "bitbucket.com"):
             path_parts = [p for p in parts.path.split("/") if p]
-            try:
-                src_idx = path_parts.index("src")
-                if src_idx >= 2 and len(path_parts) > src_idx + 2:
-                    return path_parts[-1]
-            except ValueError:
-                pass
+            if len(path_parts) >= 5 and path_parts[2] == "src":
+            return path_parts[-1]
 
         # parse real repository name from Github
         if parts.netloc == "github.com" and parts.path.count("/") > 2:

--- a/platformio/package/meta.py
+++ b/platformio/package/meta.py
@@ -428,14 +428,14 @@ class PackageSpec:  # pylint: disable=too-many-instance-attributes
         # Handle browse URLs with subdirectory
         # GitHub/GitLab: /user/repo/tree/branch/subdir
         if parts.netloc in ("github.com", "gitlab.com"):
-        path_parts = [p for p in parts.path.split("/") if p and p != "-"]
-        if len(path_parts) >= 5 and path_parts[2] == "tree":
-            return path_parts[-1]
+            path_parts = [p for p in parts.path.split("/") if p and p != "-"]
+            if len(path_parts) >= 5 and path_parts[2] == "tree":
+                return path_parts[-1]
         # Bitbucket: /user/repo/src/branch/subdir
         elif parts.netloc in ("bitbucket.org", "bitbucket.com"):
             path_parts = [p for p in parts.path.split("/") if p]
             if len(path_parts) >= 5 and path_parts[2] == "src":
-            return path_parts[-1]
+                return path_parts[-1]
 
         # parse real repository name from Github
         if parts.netloc == "github.com" and parts.path.count("/") > 2:

--- a/platformio/package/meta.py
+++ b/platformio/package/meta.py
@@ -423,8 +423,29 @@ class PackageSpec:  # pylint: disable=too-many-instance-attributes
             if c in uri:
                 uri = uri[: uri.index(c)]
 
-        # parse real repository name from Github
         parts = urlparse(uri)
+
+        # Handle browse URLs with subdirectory
+        # GitHub/GitLab: /user/repo/tree/branch/subdir
+        if parts.netloc in ("github.com", "gitlab.com"):
+            path_parts = [p for p in parts.path.split("/") if p and p != "-"]
+            try:
+                tree_idx = path_parts.index("tree")
+                if tree_idx >= 2 and len(path_parts) > tree_idx + 2:
+                    return path_parts[-1]
+            except ValueError:
+                pass
+        # Bitbucket: /user/repo/src/branch/subdir
+        elif parts.netloc in ("bitbucket.org", "bitbucket.com"):
+            path_parts = [p for p in parts.path.split("/") if p]
+            try:
+                src_idx = path_parts.index("src")
+                if src_idx >= 2 and len(path_parts) > src_idx + 2:
+                    return path_parts[-1]
+            except ValueError:
+                pass
+
+        # parse real repository name from Github
         if parts.netloc == "github.com" and parts.path.count("/") > 2:
             return parts.path.split("/")[2]
 

--- a/platformio/package/meta.py
+++ b/platformio/package/meta.py
@@ -430,12 +430,12 @@ class PackageSpec:  # pylint: disable=too-many-instance-attributes
         if parts.netloc in ("github.com", "gitlab.com"):
             path_parts = [p for p in parts.path.split("/") if p and p != "-"]
             if len(path_parts) >= 5 and path_parts[2] == "tree":
-                return path_parts[-1]
+                return path_parts[1]
         # Bitbucket: /user/repo/src/branch/subdir
         elif parts.netloc in ("bitbucket.org", "bitbucket.com"):
             path_parts = [p for p in parts.path.split("/") if p]
             if len(path_parts) >= 5 and path_parts[2] == "src":
-                return path_parts[-1]
+                return path_parts[1]
 
         # parse real repository name from Github
         if parts.netloc == "github.com" and parts.path.count("/") > 2:

--- a/platformio/package/vcsclient.py
+++ b/platformio/package/vcsclient.py
@@ -39,6 +39,12 @@ class VCSClientFactory:
             remote_url = remote_url[len(type_) + 1 :]
         if "#" in remote_url:
             remote_url, tag = remote_url.rsplit("#", 1)
+
+        # Parse subdirectory from browse URLs (e.g., GitHub /tree/branch/subdir)
+        remote_url, browse_tag, subdir = VCSClientFactory._parse_browse_url(remote_url)
+        if browse_tag and not tag:
+            tag = browse_tag
+
         if not type_:
             raise VCSBaseException("VCS: Unknown repository type %s" % remote_url)
         try:
@@ -46,11 +52,53 @@ class VCSClientFactory:
                 src_dir, remote_url, tag, silent
             )
             assert isinstance(obj, VCSClientBase)
+            obj.subdir = subdir
             return obj
         except (KeyError, AssertionError) as exc:
             raise VCSBaseException(
                 "VCS: Unknown repository type %s" % remote_url
             ) from exc
+
+    @staticmethod
+    def _parse_browse_url(remote_url):
+        """Parse subdirectory from VCS hosting browse URLs.
+
+        Supports:
+        - GitHub: https://github.com/user/repo/tree/branch/subdir
+        - GitLab: https://gitlab.com/user/repo/-/tree/branch/subdir
+        - Bitbucket: https://bitbucket.org/user/repo/src/branch/subdir
+
+        Returns (remote_url, tag, subdir) tuple.
+        """
+        parts = urlparse(remote_url)
+        path_parts = [p for p in parts.path.split("/") if p]
+
+        if len(path_parts) < 4:
+            return remote_url, None, None
+
+        owner, repo = path_parts[0], path_parts[1]
+        rest = path_parts[2:]
+
+        # Handle GitLab's /-/ prefix
+        if parts.netloc == "gitlab.com" and rest[0] == "-":
+            rest = rest[1:]
+
+        subdir_markers = {
+            "github.com": "tree",
+            "gitlab.com": "tree",
+            "bitbucket.org": "src",
+            "bitbucket.com": "src",
+        }
+
+        marker = subdir_markers.get(parts.netloc)
+        if not marker or not rest or rest[0] != marker or len(rest) < 2:
+            return remote_url, None, None
+
+        tag = rest[1]
+        subdir = "/".join(rest[2:]) if len(rest) > 2 else None
+        base_url = "%s://%s/%s/%s" % (parts.scheme, parts.netloc, owner, repo)
+
+        return base_url, tag, subdir
 
 
 class VCSClientBase:
@@ -61,6 +109,7 @@ class VCSClientBase:
         self.remote_url = remote_url
         self.tag = tag
         self.silent = silent
+        self.subdir = None
         self.check_client()
 
     def check_client(self):

--- a/platformio/package/vcsclient.py
+++ b/platformio/package/vcsclient.py
@@ -56,9 +56,8 @@ class VCSClientFactory:
             raise VCSBaseException(
                 "VCS: Unknown repository type %s" % remote_url
             ) from exc
-        else:
-            obj.subdir = subdir
-            return obj
+        obj.subdir = subdir
+        return obj
 
     @staticmethod
     def _parse_browse_url(remote_url):

--- a/platformio/package/vcsclient.py
+++ b/platformio/package/vcsclient.py
@@ -52,21 +52,23 @@ class VCSClientFactory:
                 src_dir, remote_url, tag, silent
             )
             assert isinstance(obj, VCSClientBase)
-            obj.subdir = subdir
-            return obj
         except (KeyError, AssertionError) as exc:
             raise VCSBaseException(
                 "VCS: Unknown repository type %s" % remote_url
             ) from exc
+        else:
+            obj.subdir = subdir
+            return obj
 
     @staticmethod
     def _parse_browse_url(remote_url):
         """Parse subdirectory from VCS hosting browse URLs.
 
-        Supports:
-        - GitHub: https://github.com/user/repo/tree/branch/subdir
-        - GitLab: https://gitlab.com/user/repo/-/tree/branch/subdir
-        - Bitbucket: https://bitbucket.org/user/repo/src/branch/subdir
+        Supports single-level owner/repo paths:
+        - GitHub: https://github.com/owner/repo/tree/branch/subdir
+        - GitLab: https://gitlab.com/owner/repo/-/tree/branch/subdir
+          (nested subgroups like owner/group/repo are not supported)
+        - Bitbucket: https://bitbucket.org/owner/repo/src/branch/subdir
 
         Returns (remote_url, tag, subdir) tuple.
         """
@@ -95,7 +97,10 @@ class VCSClientFactory:
             return remote_url, None, None
 
         tag = rest[1]
-        subdir = "/".join(rest[2:]) if len(rest) > 2 else None
+        subdir_parts = rest[2:]
+        if any(s in ("", ".", "..") for s in subdir_parts):
+            return remote_url, None, None
+        subdir = "/".join(subdir_parts) if subdir_parts else None
         base_url = "%s://%s/%s/%s" % (parts.scheme, parts.netloc, owner, repo)
 
         return base_url, tag, subdir

--- a/platformio/package/vcsclient.py
+++ b/platformio/package/vcsclient.py
@@ -15,7 +15,7 @@
 import os
 import re
 import subprocess
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from platformio import proc
 from platformio.exception import UserSideException
@@ -96,7 +96,7 @@ class VCSClientFactory:
             return remote_url, None, None
 
         tag = rest[1]
-        subdir_parts = rest[2:]
+        subdir_parts = [unquote(s) for s in rest[2:]]
         if any(s in ("", ".", "..") for s in subdir_parts):
             return remote_url, None, None
         subdir = "/".join(subdir_parts) if subdir_parts else None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install packages from subdirectories inside VCS repositories.
  * Improved extraction of repository names from GitHub, GitLab, and Bitbucket browse-style URLs.
  * Browse-style VCS URLs now recognize subdirectories and can infer implicit version tags; subdirectory info is preserved during client creation.

* **Bug Fixes**
  * Validate VCS subdirectory paths and report clear errors when subdirectories are missing or point outside the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->