### PR TITLE
Add esp-decoder to VSCode recommendations

### DIFF
--- a/platformio/debug/process/server.py
+++ b/platformio/debug/process/server.py
@@ -74,7 +74,7 @@ class DebugServerProcess(DebugBaseProcess):
             if server["cwd"]:
                 args.extend(["-s", server["cwd"]])
             args.extend(
-                ["-c", "gdb_port pipe; tcl_port disabled; telnet_port disabled"]
+                ["-c", "gdb port pipe; tcl port disabled; telnet port disabled"]
             )
             args.extend(server["arguments"])
             str_args = " ".join(

--- a/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl
+++ b/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl
@@ -2,7 +2,7 @@
 % import os
 % import re
 %
-% recommendations = set(["pioarduino.pioarduino-ide"])
+% recommendations = set(["pioarduino.pioarduino-ide", "Jason2866.esp-decoder"])
 % unwantedRecommendations = set(["ms-vscode.cpptools-extension-pack"])
 % previous_json = os.path.join(project_dir, ".vscode", "extensions.json")
 % if os.path.isfile(previous_json):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added the esp-decoder extension to the recommended VS Code extensions template to simplify development setup and onboarding.

* **Bug Fixes**
  * Updated debug server startup configuration so the GDB port is correctly exposed while other ports remain disabled, improving remote debug reliability and clarifying port behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->