### PR TITLE
manage VSC extension

### DIFF
--- a/platformio/project/integration/tpls/vscode/.gitignore.tpl
+++ b/platformio/project/integration/tpls/vscode/.gitignore.tpl
@@ -1,5 +1,8 @@
 .pio
+.cache
+.dummy
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+compile_commands.json

--- a/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl
+++ b/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl
@@ -2,7 +2,7 @@
 % import os
 % import re
 %
-% recommendations = set(["pioarduino.pioarduino-ide"])
+% recommendations = set(["pioarduino.pioarduino-ide", "Jason2866.esp-decoder"])
 % unwantedRecommendations = set(["ms-vscode.cpptools-extension-pack"])
 % previous_json = os.path.join(project_dir, ".vscode", "extensions.json")
 % if os.path.isfile(previous_json):


### PR DESCRIPTION
- add files and folder to .gitignore
- add VSC extension esp-decoder to recommendations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved project configuration by excluding additional temporary and build files from version control
  * Expanded VS Code recommended extensions to enhance the development experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->