### PR TITLE
add retry to FileDownloader for transient errors

### DIFF
--- a/platformio/__init__.py
+++ b/platformio/__init__.py
@@ -15,7 +15,7 @@
 VERSION = (6, 1, 19)
 __version__ = ".".join([str(s) for s in VERSION])
 
-__title__ = "pioarduino core"
+__title__ = "pioarduino"
 __description__ = (
     "pioarduino core is needed to run pioarduino Platform espressif32. "
 )

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -137,7 +137,7 @@ class FileDownloader:
                         "Got the unrecognized status code '%d' "
                         "when downloading %s"
                         % (self._http_response.status_code, self._url)
-                    )
+                    ) from exc
 
     def start(self, with_progress=True, silent=False):
         label = "Downloading"

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -19,6 +19,7 @@ from time import mktime
 
 import click
 import requests.adapters
+import requests.exceptions
 from urllib3.util.retry import Retry
 
 from platformio import fs
@@ -32,6 +33,7 @@ class FileDownloader:
         total=5,
         backoff_factor=1,
         status_forcelist=[413, 429, 500, 502, 503, 504],
+        raise_on_status=False,
     )
 
     def __init__(self, url, dest_dir=None):
@@ -41,10 +43,13 @@ class FileDownloader:
         self._http_session.mount("http://", adapter)
         self._http_response = None
         # make connection
-        self._http_response = self._http_session.get(
-            url,
-            stream=True,
-        )
+        try:
+            self._http_response = self._http_session.get(
+                url,
+                stream=True,
+            )
+        except requests.exceptions.RequestException as exc:
+            raise PackageException(str(exc)) from exc
         if self._http_response.status_code not in (200, 203):
             raise PackageException(
                 "Got the unrecognized status code '{0}' when downloaded {1}".format(

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -57,13 +57,7 @@ class FileDownloader:
                     self._http_response.status_code, url
                 )
             )
-        if "content-length" in self._http_response.headers:
-            self._content_length = int(
-                self._http_response.headers["content-length"]
-            )
-        self._resume_validator = self._http_response.headers.get(
-            "ETag"
-        ) or self._http_response.headers.get("Last-Modified")
+        self._update_response_metadata()
 
         disposition = self._http_response.headers.get("content-disposition")
         if disposition and "filename=" in disposition:
@@ -91,14 +85,22 @@ class FileDownloader:
     def get_size(self):
         return self._content_length
 
+    def _update_response_metadata(self):
+        if "content-length" in self._http_response.headers:
+            self._content_length = int(
+                self._http_response.headers["content-length"]
+            )
+        self._resume_validator = self._http_response.headers.get(
+            "ETag"
+        ) or self._http_response.headers.get("Last-Modified")
+
     def _request_stream(self, resume_from=0):
         if self._http_response:
             self._http_response.close()
         headers = {}
-        if resume_from > 0:
+        if resume_from > 0 and self._resume_validator:
             headers["Range"] = f"bytes={resume_from}-"
-            if self._resume_validator:
-                headers["If-Range"] = self._resume_validator
+            headers["If-Range"] = self._resume_validator
         try:
             self._http_response = self._http_session.get(
                 self._url,
@@ -163,6 +165,7 @@ class FileDownloader:
                 if self._needs_restart(downloaded_size):
                     if self._http_response.status_code == 206:
                         self._request_stream(resume_from=0)
+                    self._update_response_metadata()
                     fp.seek(0)
                     fp.truncate()
                     downloaded_size = 0

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -162,6 +162,25 @@ class FileDownloader:
                     downloaded_size = 0
                     yield _STREAM_RESET
 
+    @staticmethod
+    def _consume_with_percent(itercontent, file_size, label):
+        click.echo(f"{label} 0%", nl=False)
+        print_percent_step = 10
+        printed_percents = 0
+        downloaded_size = 0
+        for chunk in itercontent:
+            if chunk is _STREAM_RESET:
+                downloaded_size = 0
+                printed_percents = 0
+                continue
+            downloaded_size += len(chunk)
+            if (downloaded_size / file_size * 100) >= (
+                printed_percents + print_percent_step
+            ):
+                printed_percents += print_percent_step
+                click.echo(f" {printed_percents}%", nl=False)
+        click.echo("")
+
     def start(self, with_progress=True, silent=False):
         label = "Downloading"
         file_size = self.get_size()
@@ -177,22 +196,7 @@ class FileDownloader:
                             continue
 
                 elif not is_terminal():
-                    click.echo(f"{label} 0%", nl=False)
-                    print_percent_step = 10
-                    printed_percents = 0
-                    downloaded_size = 0
-                    for chunk in itercontent:
-                        if chunk is _STREAM_RESET:
-                            downloaded_size = 0
-                            printed_percents = 0
-                            continue
-                        downloaded_size += len(chunk)
-                        if (downloaded_size / file_size * 100) >= (
-                            printed_percents + print_percent_step
-                        ):
-                            printed_percents += print_percent_step
-                            click.echo(f" {printed_percents}%", nl=False)
-                    click.echo("")
+                    self._consume_with_percent(itercontent, file_size, label)
 
                 else:
                     with click.progressbar(

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -48,6 +48,7 @@ class FileDownloader:
         self._http_session.mount("http://", adapter)
         self._http_response = None
         self._content_length = -1
+        self._resume_validator = None
         # make connection
         self._request_stream()
         if self._http_response.status_code not in (200, 203):
@@ -60,6 +61,9 @@ class FileDownloader:
             self._content_length = int(
                 self._http_response.headers["content-length"]
             )
+        self._resume_validator = self._http_response.headers.get(
+            "ETag"
+        ) or self._http_response.headers.get("Last-Modified")
 
         disposition = self._http_response.headers.get("content-disposition")
         if disposition and "filename=" in disposition:
@@ -93,6 +97,8 @@ class FileDownloader:
         headers = {}
         if resume_from > 0:
             headers["Range"] = f"bytes={resume_from}-"
+            if self._resume_validator:
+                headers["If-Range"] = self._resume_validator
         try:
             self._http_response = self._http_session.get(
                 self._url,
@@ -101,7 +107,7 @@ class FileDownloader:
             )
         except requests.exceptions.RequestException as exc:
             self._http_response = None
-            raise PackageException(str(exc)) from exc
+            raise IOError(str(exc)) from exc
 
     def _stream_with_retry(self, fp):
         max_retries = self.RETRY.total
@@ -124,7 +130,7 @@ class FileDownloader:
                 self._http_response.close()
                 attempt += 1
                 if attempt >= max_retries:
-                    raise PackageException(
+                    raise IOError(
                         "Download failed after %d retries: %s"
                         % (max_retries, exc)
                     ) from exc
@@ -214,7 +220,8 @@ class FileDownloader:
                                 continue
                             pb.update(len(chunk))
         finally:
-            self._http_response.close()
+            if self._http_response:
+                self._http_response.close()
             self._http_session.close()
 
         if self.get_lmtime():

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -18,6 +18,8 @@ from os.path import getsize, join
 from time import mktime
 
 import click
+import requests.adapters
+from urllib3.util.retry import Retry
 
 from platformio import fs
 from platformio.compat import is_terminal
@@ -26,8 +28,17 @@ from platformio.package.exception import PackageException
 
 
 class FileDownloader:
+    RETRY = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[413, 429, 500, 502, 503, 504],
+    )
+
     def __init__(self, url, dest_dir=None):
         self._http_session = HTTPSession()
+        adapter = requests.adapters.HTTPAdapter(max_retries=self.RETRY)
+        self._http_session.mount("https://", adapter)
+        self._http_session.mount("http://", adapter)
         self._http_response = None
         # make connection
         self._http_response = self._http_session.get(

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import io
+import time
 from email.utils import parsedate
 from os.path import getsize, join
 from time import mktime
@@ -37,19 +38,14 @@ class FileDownloader:
     )
 
     def __init__(self, url, dest_dir=None):
+        self._url = url
         self._http_session = HTTPSession()
         adapter = requests.adapters.HTTPAdapter(max_retries=self.RETRY)
         self._http_session.mount("https://", adapter)
         self._http_session.mount("http://", adapter)
         self._http_response = None
         # make connection
-        try:
-            self._http_response = self._http_session.get(
-                url,
-                stream=True,
-            )
-        except requests.exceptions.RequestException as exc:
-            raise PackageException(str(exc)) from exc
+        self._request_stream()
         if self._http_response.status_code not in (200, 203):
             raise PackageException(
                 "Got the unrecognized status code '{0}' when downloaded {1}".format(
@@ -85,19 +81,76 @@ class FileDownloader:
             return -1
         return int(self._http_response.headers["content-length"])
 
+    def _request_stream(self, resume_from=0):
+        if self._http_response:
+            self._http_response.close()
+        headers = {}
+        if resume_from > 0:
+            headers["Range"] = f"bytes={resume_from}-"
+        try:
+            self._http_response = self._http_session.get(
+                self._url,
+                stream=True,
+                headers=headers,
+            )
+        except requests.exceptions.RequestException as exc:
+            self._http_response = None
+            raise PackageException(str(exc)) from exc
+
+    def _stream_with_retry(self, fp):
+        max_retries = self.RETRY.total
+        downloaded_size = 0
+        attempt = 0
+        while True:
+            itercontent = self._http_response.iter_content(
+                chunk_size=io.DEFAULT_BUFFER_SIZE
+            )
+            try:
+                for chunk in itercontent:
+                    fp.write(chunk)
+                    downloaded_size += len(chunk)
+                    yield chunk
+                return
+            except (
+                requests.exceptions.RequestException,
+                IOError,
+            ) as exc:
+                self._http_response.close()
+                attempt += 1
+                if attempt >= max_retries:
+                    raise PackageException(
+                        "Download failed after %d retries: %s"
+                        % (max_retries, exc)
+                    ) from exc
+                backoff = self.RETRY.backoff_factor * (2 ** (attempt - 1))
+                time.sleep(backoff)
+                self._request_stream(resume_from=downloaded_size)
+                if self._http_response.status_code == 206:
+                    pass  # server supports range, continue appending
+                elif self._http_response.status_code in (200, 203):
+                    # server restarted from beginning, reset
+                    fp.seek(0)
+                    fp.truncate()
+                    downloaded_size = 0
+                else:
+                    raise PackageException(
+                        "Got the unrecognized status code '%d' "
+                        "when downloading %s"
+                        % (self._http_response.status_code, self._url)
+                    )
+
     def start(self, with_progress=True, silent=False):
         label = "Downloading"
         file_size = self.get_size()
-        itercontent = self._http_response.iter_content(
-            chunk_size=io.DEFAULT_BUFFER_SIZE
-        )
         try:
             with open(self._destination, "wb") as fp:
+                itercontent = self._stream_with_retry(fp)
+
                 if file_size == -1 or not with_progress or silent:
                     if not silent:
                         click.echo(f"{label}...")
-                    for chunk in itercontent:
-                        fp.write(chunk)
+                    for _chunk in itercontent:
+                        pass
 
                 elif not is_terminal():
                     click.echo(f"{label} 0%", nl=False)
@@ -105,7 +158,6 @@ class FileDownloader:
                     printed_percents = 0
                     downloaded_size = 0
                     for chunk in itercontent:
-                        fp.write(chunk)
                         downloaded_size += len(chunk)
                         if (downloaded_size / file_size * 100) >= (
                             printed_percents + print_percent_step
@@ -125,7 +177,6 @@ class FileDownloader:
                     ) as pb:
                         for chunk in pb:
                             pb.update(len(chunk))
-                            fp.write(chunk)
         finally:
             self._http_response.close()
             self._http_session.close()

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -29,6 +29,9 @@ from platformio.http import HTTPSession
 from platformio.package.exception import PackageException
 
 
+_STREAM_RESET = object()
+
+
 class FileDownloader:
     RETRY = Retry(
         total=5,
@@ -44,6 +47,7 @@ class FileDownloader:
         self._http_session.mount("https://", adapter)
         self._http_session.mount("http://", adapter)
         self._http_response = None
+        self._content_length = -1
         # make connection
         self._request_stream()
         if self._http_response.status_code not in (200, 203):
@@ -51,6 +55,10 @@ class FileDownloader:
                 "Got the unrecognized status code '{0}' when downloaded {1}".format(
                     self._http_response.status_code, url
                 )
+            )
+        if "content-length" in self._http_response.headers:
+            self._content_length = int(
+                self._http_response.headers["content-length"]
             )
 
         disposition = self._http_response.headers.get("content-disposition")
@@ -77,9 +85,7 @@ class FileDownloader:
         return self._http_response.headers.get("last-modified")
 
     def get_size(self):
-        if "content-length" not in self._http_response.headers:
-            return -1
-        return int(self._http_response.headers["content-length"])
+        return self._content_length
 
     def _request_stream(self, resume_from=0):
         if self._http_response:
@@ -125,19 +131,36 @@ class FileDownloader:
                 backoff = self.RETRY.backoff_factor * (2 ** (attempt - 1))
                 time.sleep(backoff)
                 self._request_stream(resume_from=downloaded_size)
+                restart = False
                 if self._http_response.status_code == 206:
-                    pass  # server supports range, continue appending
+                    content_range = self._http_response.headers.get(
+                        "Content-Range", ""
+                    )
+                    # Expected: "bytes <start>-<end>/<total>"
+                    if content_range.startswith("bytes "):
+                        try:
+                            range_start = int(
+                                content_range[6:].split("-", 1)[0]
+                            )
+                        except (ValueError, IndexError):
+                            range_start = -1
+                        if range_start != downloaded_size:
+                            restart = True
+                    else:
+                        restart = True
                 elif self._http_response.status_code in (200, 203):
-                    # server restarted from beginning, reset
-                    fp.seek(0)
-                    fp.truncate()
-                    downloaded_size = 0
+                    restart = True
                 else:
                     raise PackageException(
                         "Got the unrecognized status code '%d' "
                         "when downloading %s"
                         % (self._http_response.status_code, self._url)
                     ) from exc
+                if restart:
+                    fp.seek(0)
+                    fp.truncate()
+                    downloaded_size = 0
+                    yield _STREAM_RESET
 
     def start(self, with_progress=True, silent=False):
         label = "Downloading"
@@ -149,8 +172,9 @@ class FileDownloader:
                 if file_size == -1 or not with_progress or silent:
                     if not silent:
                         click.echo(f"{label}...")
-                    for _chunk in itercontent:
-                        pass
+                    for chunk in itercontent:
+                        if chunk is _STREAM_RESET:
+                            continue
 
                 elif not is_terminal():
                     click.echo(f"{label} 0%", nl=False)
@@ -158,6 +182,10 @@ class FileDownloader:
                     printed_percents = 0
                     downloaded_size = 0
                     for chunk in itercontent:
+                        if chunk is _STREAM_RESET:
+                            downloaded_size = 0
+                            printed_percents = 0
+                            continue
                         downloaded_size += len(chunk)
                         if (downloaded_size / file_size * 100) >= (
                             printed_percents + print_percent_step
@@ -176,6 +204,10 @@ class FileDownloader:
                         ),  # every 256Kb or less
                     ) as pb:
                         for chunk in pb:
+                            if chunk is _STREAM_RESET:
+                                pb.pos = 0
+                                pb.finished = False
+                                continue
                             pb.update(len(chunk))
         finally:
             self._http_response.close()

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -161,7 +161,8 @@ class FileDownloader:
                         % (self._http_response.status_code, self._url)
                     ) from exc
                 if self._needs_restart(downloaded_size):
-                    self._request_stream(resume_from=0)
+                    if self._http_response.status_code == 206:
+                        self._request_stream(resume_from=0)
                     fp.seek(0)
                     fp.truncate()
                     downloaded_size = 0

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -109,6 +109,22 @@ class FileDownloader:
             self._http_response = None
             raise IOError(str(exc)) from exc
 
+    def _needs_restart(self, downloaded_size):
+        if self._http_response.status_code == 206:
+            content_range = self._http_response.headers.get(
+                "Content-Range", ""
+            )
+            if content_range.startswith("bytes "):
+                try:
+                    range_start = int(
+                        content_range[6:].split("-", 1)[0]
+                    )
+                except (ValueError, IndexError):
+                    range_start = -1
+                return range_start != downloaded_size
+            return True
+        return self._http_response.status_code in (200, 203)
+
     def _stream_with_retry(self, fp):
         max_retries = self.RETRY.total
         downloaded_size = 0
@@ -119,14 +135,15 @@ class FileDownloader:
             )
             try:
                 for chunk in itercontent:
-                    fp.write(chunk)
+                    try:
+                        fp.write(chunk)
+                    except IOError:
+                        self._http_response.close()
+                        raise
                     downloaded_size += len(chunk)
                     yield chunk
                 return
-            except (
-                requests.exceptions.RequestException,
-                IOError,
-            ) as exc:
+            except requests.exceptions.RequestException as exc:
                 self._http_response.close()
                 attempt += 1
                 if attempt >= max_retries:
@@ -137,32 +154,14 @@ class FileDownloader:
                 backoff = self.RETRY.backoff_factor * (2 ** (attempt - 1))
                 time.sleep(backoff)
                 self._request_stream(resume_from=downloaded_size)
-                restart = False
-                if self._http_response.status_code == 206:
-                    content_range = self._http_response.headers.get(
-                        "Content-Range", ""
-                    )
-                    # Expected: "bytes <start>-<end>/<total>"
-                    if content_range.startswith("bytes "):
-                        try:
-                            range_start = int(
-                                content_range[6:].split("-", 1)[0]
-                            )
-                        except (ValueError, IndexError):
-                            range_start = -1
-                        if range_start != downloaded_size:
-                            restart = True
-                    else:
-                        restart = True
-                elif self._http_response.status_code in (200, 203):
-                    restart = True
-                else:
+                if self._http_response.status_code not in (200, 203, 206):
                     raise PackageException(
                         "Got the unrecognized status code '%d' "
                         "when downloading %s"
                         % (self._http_response.status_code, self._url)
                     ) from exc
-                if restart:
+                if self._needs_restart(downloaded_size):
+                    self._request_stream(resume_from=0)
                     fp.seek(0)
                     fp.truncate()
                     downloaded_size = 0

--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -179,6 +179,8 @@ class FileDownloader:
         downloaded_size = 0
         for chunk in itercontent:
             if chunk is _STREAM_RESET:
+                click.echo("")
+                click.echo(f"{label} 0%", nl=False)
                 downloaded_size = 0
                 printed_percents = 0
                 continue

--- a/tests/misc/test_maintenance.py
+++ b/tests/misc/test_maintenance.py
@@ -14,37 +14,4 @@
 
 # pylint: disable=unused-argument
 
-from time import time
-
-from platformio import app, maintenance
-from platformio.__main__ import cli as cli_pio
-from platformio.commands import upgrade as cmd_upgrade
-
-
-def test_check_pio_upgrade(clirunner, isolated_pio_core, validate_cliresult):
-    def _patch_pio_version(version):
-        maintenance.__version__ = version
-        cmd_upgrade.VERSION = version.split(".", 3)
-
-    interval = int(app.get_setting("check_platformio_interval")) * 3600 * 24
-    last_check = {"platformio_upgrade": time() - interval - 1}
-    origin_version = maintenance.__version__
-
-    # check development version
-    _patch_pio_version("3.0.0-a1")
-    app.set_state_item("last_check", last_check)
-    result = clirunner.invoke(cli_pio, ["platform", "list"])
-    validate_cliresult(result)
-    assert "There is a new version" in result.output
-    assert "Please upgrade" in result.output
-
-    # check stable version
-    _patch_pio_version("2.11.0")
-    app.set_state_item("last_check", last_check)
-    result = clirunner.invoke(cli_pio, ["platform", "list"])
-    validate_cliresult(result)
-    assert "There is a new version" in result.output
-    assert "Please upgrade" in result.output
-
-    # restore original version
-    _patch_pio_version(origin_version)
+# pioarduino change: upgrade check is disabled, so test_check_pio_upgrade is removed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads now support resumable streaming with automatic retry and exponential backoff.
  * Remote file size is cached to speed size reporting and resume decisions.

* **Bug Fixes**
  * Interrupted downloads resume or restart cleanly when resumption validation fails.
  * Progress percentage and progress-bar output correctly reflect retries and restarts.
  * Network and I/O errors are surfaced consistently as package-level errors.

* **Chores**
  * Package title updated to "pioarduino".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->