### PR TITLE
fix: do not crash when `file://` is not found

### DIFF
--- a/platformio/package/manager/_install.py
+++ b/platformio/package/manager/_install.py
@@ -107,7 +107,7 @@ class PackageManagerInstallMixin:
                 ),
             )
 
-        if not pkg or not pkg.metadata:
+        if not pkg:
             if spec.external and spec.uri and spec.uri.startswith("file://"):
                 self.log.warning(
                     click.style(
@@ -117,6 +117,7 @@ class PackageManagerInstallMixin:
                     )
                 )
                 return None
+        if not pkg or not pkg.metadata:
             raise PackageException(
                 "Could not install package '%s' for '%s' system"
                 % (spec.humanize(), util.get_systype())

--- a/platformio/package/manager/_install.py
+++ b/platformio/package/manager/_install.py
@@ -108,6 +108,15 @@ class PackageManagerInstallMixin:
             )
 
         if not pkg or not pkg.metadata:
+            if spec.external and spec.uri and spec.uri.startswith("file://"):
+                self.log.warning(
+                    click.style(
+                        "Warning! Could not install package '%s': path not found, "
+                        "skipping..." % spec.humanize(),
+                        fg="yellow",
+                    )
+                )
+                return None
             raise PackageException(
                 "Could not install package '%s' for '%s' system"
                 % (spec.humanize(), util.get_systype())
@@ -182,9 +191,15 @@ class PackageManagerInstallMixin:
                 _uri = uri[7:]
                 if os.path.isfile(_uri):
                     self.unpack(_uri, tmp_dir)
-                else:
+                elif os.path.isdir(_uri):
                     fs.rmtree(tmp_dir)
                     shutil.copytree(_uri, tmp_dir, symlinks=True)
+                else:
+                    click.secho(
+                        "Warning! Library not found at %s, skipping..." % _uri,
+                        fg="yellow",
+                    )
+                    return None
             elif uri.startswith(("http://", "https://")):
                 dl_path = self.download(uri, checksum)
                 assert os.path.isfile(dl_path)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Missing local external packages are now skipped gracefully with improved logging
  * Enhanced local file path validation that distinguishes between files and directories, emitting warnings for invalid paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->